### PR TITLE
sign_in画面の追加

### DIFF
--- a/app/sign_in/page.tsx
+++ b/app/sign_in/page.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+const SignIn = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-2xl font-bold underline py-5">Sign In</h1>
+      <form className="flex flex-col items-center">
+        <div>
+          <p className="text-gray-800">Email</p>
+          <input
+            type="email"
+            placeholder="Enter your name"
+            className="bg-gray-200 shadow border-2 border-gray-400 appearance-none rounded w-full py-2 px-3 text-gray-800 leading-tight focus:outline-none focus:shadow-outline"
+          />
+        </div>
+        <div className="py-5">
+          <p className="text-gray-800">Password</p>
+          <input
+            type="password"
+            placeholder="Enter your name"
+            className="bg-gray-200 shadow border-2 border-gray-400 appearance-none rounded w-full py-2 px-3 text-gray-800 leading-tight focus:outline-none focus:shadow-outline"
+          />
+        </div>
+        <button className="flex h-9 items-center justify-center rounded-full bg-gradient-to-b from-blue-400 from-50% to-blue-500 to-50% px-3 text-blue-50 hover:from-blue-500 hover:to-blue-600 active:from-blue-600 active:to-blue-700 mt-4">
+          Sign In
+        </button>
+      </form>
+      <div className="flex items-center mt-4">
+        <span>Don&apos;t have an account?</span>
+        <span className="text-blue-400 ml-1"> sign Up</span>
+      </div>
+    </div>
+  );
+};
+
+export default SignIn;


### PR DESCRIPTION
close #16 

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）
sign_in画面をSign_up画面をもとに追加しています。
TailwindCSSを使用しデザインを今の自分でできる限りワイヤーフレームに寄せました。

![image](https://github.com/user-attachments/assets/16bfa94a-1be3-4cfe-82ee-11489b839662)

